### PR TITLE
Updates contribution link to Oqtane reposistory

### DIFF
--- a/docs/admin/admin-dashboard/file-management.html
+++ b/docs/admin/admin-dashboard/file-management.html
@@ -116,7 +116,7 @@ The options provided by the file manager are:</p>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/file-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/file-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/index.html
+++ b/docs/admin/admin-dashboard/index.html
@@ -120,7 +120,7 @@ If you want to add new options to the admin dashboard, then that can be done by 
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/page-management.html
+++ b/docs/admin/admin-dashboard/page-management.html
@@ -143,7 +143,7 @@ Specific Users: The permissions tab also has the ability for you to enter a spec
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/page-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/page-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/profile-management.html
+++ b/docs/admin/admin-dashboard/profile-management.html
@@ -126,7 +126,7 @@ The profile page has an add profile button at the top of its page which includes
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/profile-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/profile-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/recycle-bin.html
+++ b/docs/admin/admin-dashboard/recycle-bin.html
@@ -111,7 +111,7 @@ The recycle bin feature has two options, restore and delete. With the restore bu
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/recycle-bin.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/recycle-bin.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/role-management.html
+++ b/docs/admin/admin-dashboard/role-management.html
@@ -113,7 +113,7 @@ When adding a user into a role, there are fields for effective date and expiry d
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/role-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/role-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/site-settings.html
+++ b/docs/admin/admin-dashboard/site-settings.html
@@ -141,7 +141,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/site-settings.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/site-settings.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/admin-dashboard/user-management.html
+++ b/docs/admin/admin-dashboard/user-management.html
@@ -123,7 +123,7 @@ There is also the profile tab which goes into more detail about a user allowing 
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/user-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/admin-dashboard/user-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/control-panel/control-page.html
+++ b/docs/admin/control-panel/control-page.html
@@ -146,7 +146,7 @@ Specific Users: The permissions tab also has the ability for you to enter a spec
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/control-page.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/control-page.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/control-panel/index.html
+++ b/docs/admin/control-panel/index.html
@@ -116,7 +116,7 @@ It is worth noting that the Control Panel you'll be using is the one that ships 
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/control-panel/modules.html
+++ b/docs/admin/control-panel/modules.html
@@ -135,7 +135,7 @@ The other module options below this are:</p>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/modules.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/modules.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/control-panel/page-management.html
+++ b/docs/admin/control-panel/page-management.html
@@ -146,7 +146,7 @@ Specific Users: The permissions tab also has the ability for you to enter a spec
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/page-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/control-panel/page-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/event-log.html
+++ b/docs/admin/host-administration/event-log.html
@@ -143,7 +143,7 @@ For each event that is displayed you can select the detail button to show more i
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/event-log.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/event-log.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/index.html
+++ b/docs/admin/host-administration/index.html
@@ -121,7 +121,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/module-management.html
+++ b/docs/admin/host-administration/module-management.html
@@ -111,7 +111,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/module-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/module-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/scheduled-jobs.html
+++ b/docs/admin/host-administration/scheduled-jobs.html
@@ -135,7 +135,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/scheduled-jobs.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/scheduled-jobs.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/site-management.html
+++ b/docs/admin/host-administration/site-management.html
@@ -129,7 +129,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/site-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/2sic-forks/oqtane/blob/master/Oqtane.Docs/admin/host-administration/site-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/sql-management.html
+++ b/docs/admin/host-administration/sql-management.html
@@ -109,7 +109,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/sql-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/sql-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/system-info.html
+++ b/docs/admin/host-administration/system-info.html
@@ -110,7 +110,7 @@ There is also the option to restart the Oqtane framwork on this page if you have
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/system-info.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/system-info.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/system-update.html
+++ b/docs/admin/host-administration/system-update.html
@@ -108,7 +108,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/system-update.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/system-update.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/host-administration/theme-management.html
+++ b/docs/admin/host-administration/theme-management.html
@@ -111,7 +111,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/theme-management.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/host-administration/theme-management.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/index.html
+++ b/docs/admin/index.html
@@ -116,7 +116,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/installation/index.html
+++ b/docs/admin/installation/index.html
@@ -160,7 +160,7 @@ Make sure you specify Oqtane.Server as the Startup Project and then Run the appl
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/installation/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/installation/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/modules/adding-modules.html
+++ b/docs/admin/modules/adding-modules.html
@@ -123,7 +123,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/adding-modules.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/adding-modules.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/modules/index.html
+++ b/docs/admin/modules/index.html
@@ -116,7 +116,7 @@ When you install Oqtane, the platform ships with a base set of modules already i
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/modules/working-with-modules.html
+++ b/docs/admin/modules/working-with-modules.html
@@ -125,7 +125,7 @@ If the page has the layout for multiple panes, which will allows for three cente
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/working-with-modules.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/modules/working-with-modules.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/site-administration/content-editor.html
+++ b/docs/admin/site-administration/content-editor.html
@@ -136,7 +136,7 @@ If the page has the layout for multiple panes, which will allows for three cente
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/site-administration/content-editor.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/site-administration/content-editor.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/admin/site-administration/index.html
+++ b/docs/admin/site-administration/index.html
@@ -115,7 +115,7 @@ This includes things like managing users, security, site settings, configuration
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/admin/site-administration/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/admin/site-administration/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Oqtane.App.html
+++ b/docs/api/Oqtane.App.html
@@ -122,10 +122,10 @@
 </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_AntiForgeryToken.md&amp;value=---%0Auid%3A%20Oqtane.App.AntiForgeryToken%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_AntiForgeryToken.md&amp;value=---%0Auid%3A%20Oqtane.App.AntiForgeryToken%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L338">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L338">View Source</a>
   </span>
   <a id="Oqtane_App_AntiForgeryToken_" data-uid="Oqtane.App.AntiForgeryToken*"></a>
   <h4 id="Oqtane_App_AntiForgeryToken" data-uid="Oqtane.App.AntiForgeryToken">AntiForgeryToken</h4>
@@ -153,10 +153,10 @@ public string AntiForgeryToken { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_AuthorizationToken.md&amp;value=---%0Auid%3A%20Oqtane.App.AuthorizationToken%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_AuthorizationToken.md&amp;value=---%0Auid%3A%20Oqtane.App.AuthorizationToken%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L353">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L353">View Source</a>
   </span>
   <a id="Oqtane_App_AuthorizationToken_" data-uid="Oqtane.App.AuthorizationToken*"></a>
   <h4 id="Oqtane_App_AuthorizationToken" data-uid="Oqtane.App.AuthorizationToken">AuthorizationToken</h4>
@@ -184,10 +184,10 @@ public string AuthorizationToken { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_RemoteIPAddress.md&amp;value=---%0Auid%3A%20Oqtane.App.RemoteIPAddress%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_RemoteIPAddress.md&amp;value=---%0Auid%3A%20Oqtane.App.RemoteIPAddress%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L350">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L350">View Source</a>
   </span>
   <a id="Oqtane_App_RemoteIPAddress_" data-uid="Oqtane.App.RemoteIPAddress*"></a>
   <h4 id="Oqtane_App_RemoteIPAddress" data-uid="Oqtane.App.RemoteIPAddress">RemoteIPAddress</h4>
@@ -215,10 +215,10 @@ public string RemoteIPAddress { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_RenderMode.md&amp;value=---%0Auid%3A%20Oqtane.App.RenderMode%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_RenderMode.md&amp;value=---%0Auid%3A%20Oqtane.App.RenderMode%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L344">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L344">View Source</a>
   </span>
   <a id="Oqtane_App_RenderMode_" data-uid="Oqtane.App.RenderMode*"></a>
   <h4 id="Oqtane_App_RenderMode" data-uid="Oqtane.App.RenderMode">RenderMode</h4>
@@ -246,10 +246,10 @@ public string RenderMode { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_Runtime.md&amp;value=---%0Auid%3A%20Oqtane.App.Runtime%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_Runtime.md&amp;value=---%0Auid%3A%20Oqtane.App.Runtime%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L341">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L341">View Source</a>
   </span>
   <a id="Oqtane_App_Runtime_" data-uid="Oqtane.App.Runtime*"></a>
   <h4 id="Oqtane_App_Runtime" data-uid="Oqtane.App.Runtime">Runtime</h4>
@@ -277,10 +277,10 @@ public string Runtime { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_VisitorId.md&amp;value=---%0Auid%3A%20Oqtane.App.VisitorId%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_VisitorId.md&amp;value=---%0Auid%3A%20Oqtane.App.VisitorId%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L347">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L347">View Source</a>
   </span>
   <a id="Oqtane_App_VisitorId_" data-uid="Oqtane.App.VisitorId*"></a>
   <h4 id="Oqtane_App_VisitorId" data-uid="Oqtane.App.VisitorId">VisitorId</h4>
@@ -310,10 +310,10 @@ public int VisitorId { get; set; }</code></pre>
 </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_BuildRenderTree_Microsoft_AspNetCore_Components_Rendering_RenderTreeBuilder_.md&amp;value=---%0Auid%3A%20Oqtane.App.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_BuildRenderTree_Microsoft_AspNetCore_Components_Rendering_RenderTreeBuilder_.md&amp;value=---%0Auid%3A%20Oqtane.App.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L187">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L187">View Source</a>
   </span>
   <a id="Oqtane_App_BuildRenderTree_" data-uid="Oqtane.App.BuildRenderTree*"></a>
   <h4 id="Oqtane_App_BuildRenderTree_Microsoft_AspNetCore_Components_Rendering_RenderTreeBuilder_" data-uid="Oqtane.App.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">BuildRenderTree(RenderTreeBuilder)</h4>
@@ -345,10 +345,10 @@ public int VisitorId { get; set; }</code></pre>
   <div><a class="xref" href="https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.components.componentbase.buildrendertree">ComponentBase.BuildRenderTree(RenderTreeBuilder)</a></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_OnAfterRender_System_Boolean_.md&amp;value=---%0Auid%3A%20Oqtane.App.OnAfterRender(System.Boolean)%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_OnAfterRender_System_Boolean_.md&amp;value=---%0Auid%3A%20Oqtane.App.OnAfterRender(System.Boolean)%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L388">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L388">View Source</a>
   </span>
   <a id="Oqtane_App_OnAfterRender_" data-uid="Oqtane.App.OnAfterRender*"></a>
   <h4 id="Oqtane_App_OnAfterRender_System_Boolean_" data-uid="Oqtane.App.OnAfterRender(System.Boolean)">OnAfterRender(bool)</h4>
@@ -388,10 +388,10 @@ once.</p>
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_OnParametersSetAsync.md&amp;value=---%0Auid%3A%20Oqtane.App.OnParametersSetAsync%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App_OnParametersSetAsync.md&amp;value=---%0Auid%3A%20Oqtane.App.OnParametersSetAsync%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L364">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L364">View Source</a>
   </span>
   <a id="Oqtane_App_OnParametersSetAsync_" data-uid="Oqtane.App.OnParametersSetAsync*"></a>
   <h4 id="Oqtane_App_OnParametersSetAsync" data-uid="Oqtane.App.OnParametersSetAsync">OnParametersSetAsync()</h4>
@@ -430,10 +430,10 @@ the render tree, and the incoming values have been assigned to properties.</p>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App.md&amp;value=---%0Auid%3A%20Oqtane.App%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/new/master/apiSpec/new?filename=Oqtane_App.md&amp;value=---%0Auid%3A%20Oqtane.App%0Asummary%3A%20&#39;*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax&#39;%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L184" class="contribution-link">View Source</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/App_razor.g.cs/#L184" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Oqtane.Client.Program.html
+++ b/docs/api/Oqtane.Client.Program.html
@@ -120,10 +120,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Client_Program_Main_System_String___.md&amp;value=---%0Auid%3A%20Oqtane.Client.Program.Main(System.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Client_Program_Main_System_String___.md&amp;value=---%0Auid%3A%20Oqtane.Client.Program.Main(System.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Client/Program.cs/#L24">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Client/Program.cs/#L24">View Source</a>
   </span>
   <a id="Oqtane_Client_Program_Main_" data-uid="Oqtane.Client.Program.Main*"></a>
   <h4 id="Oqtane_Client_Program_Main_System_String___" data-uid="Oqtane.Client.Program.Main(System.String[])">Main(String[])</h4>
@@ -173,10 +173,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Client_Program.md&amp;value=---%0Auid%3A%20Oqtane.Client.Program%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Client_Program.md&amp;value=---%0Auid%3A%20Oqtane.Client.Program%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Client/Program.cs/#L22" class="contribution-link">View Source</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Client/Program.cs/#L22" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Oqtane.Controllers.Context.html
+++ b/docs/api/Oqtane.Controllers.Context.html
@@ -120,10 +120,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context_Base.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context.Base%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context_Base.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context.Base%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L121">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L121">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Context_Base_" data-uid="Oqtane.Controllers.Context.Base*"></a>
   <h4 id="Oqtane_Controllers_Context_Base" data-uid="Oqtane.Controllers.Context.Base">Base</h4>
@@ -151,10 +151,10 @@ public Uri Base { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context_Vocab.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context.Vocab%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context_Vocab.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context.Vocab%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L118">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L118">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Context_Vocab_" data-uid="Oqtane.Controllers.Context.Vocab*"></a>
   <h4 id="Oqtane_Controllers_Context_Vocab" data-uid="Oqtane.Controllers.Context.Vocab">Vocab</h4>
@@ -188,10 +188,10 @@ public Uri Vocab { get; set; }</code></pre>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Context.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Context%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L116" class="contribution-link">View Source</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L116" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Oqtane.Controllers.Data.html
+++ b/docs/api/Oqtane.Controllers.Data.html
@@ -120,10 +120,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Authors.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Authors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Authors.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Authors%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L163">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L163">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Authors_" data-uid="Oqtane.Controllers.Data.Authors*"></a>
   <h4 id="Oqtane_Controllers_Data_Authors" data-uid="Oqtane.Controllers.Data.Authors">Authors</h4>
@@ -151,10 +151,10 @@ public string[] Authors { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Description.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Description%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Description.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Description%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L142">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L142">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Description_" data-uid="Oqtane.Controllers.Data.Description*"></a>
   <h4 id="Oqtane_Controllers_Data_Description" data-uid="Oqtane.Controllers.Data.Description">Description</h4>
@@ -182,10 +182,10 @@ public string Description { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_IconUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.IconUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_IconUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.IconUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L151">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L151">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_IconUrl_" data-uid="Oqtane.Controllers.Data.IconUrl*"></a>
   <h4 id="Oqtane_Controllers_Data_IconUrl" data-uid="Oqtane.Controllers.Data.IconUrl">IconUrl</h4>
@@ -213,10 +213,10 @@ public Uri IconUrl { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Id.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Id.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Id%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L136">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L136">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Id_" data-uid="Oqtane.Controllers.Data.Id*"></a>
   <h4 id="Oqtane_Controllers_Data_Id" data-uid="Oqtane.Controllers.Data.Id">Id</h4>
@@ -244,10 +244,10 @@ public string Id { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_LicenseUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.LicenseUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_LicenseUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.LicenseUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L154">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L154">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_LicenseUrl_" data-uid="Oqtane.Controllers.Data.LicenseUrl*"></a>
   <h4 id="Oqtane_Controllers_Data_LicenseUrl" data-uid="Oqtane.Controllers.Data.LicenseUrl">LicenseUrl</h4>
@@ -275,10 +275,10 @@ public Uri LicenseUrl { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_ProjectUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.ProjectUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_ProjectUrl.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.ProjectUrl%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L157">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L157">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_ProjectUrl_" data-uid="Oqtane.Controllers.Data.ProjectUrl*"></a>
   <h4 id="Oqtane_Controllers_Data_ProjectUrl" data-uid="Oqtane.Controllers.Data.ProjectUrl">ProjectUrl</h4>
@@ -306,10 +306,10 @@ public Uri ProjectUrl { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Registration.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Registration%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Registration.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Registration%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L133">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L133">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Registration_" data-uid="Oqtane.Controllers.Data.Registration*"></a>
   <h4 id="Oqtane_Controllers_Data_Registration" data-uid="Oqtane.Controllers.Data.Registration">Registration</h4>
@@ -337,10 +337,10 @@ public Uri Registration { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Summary.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Summary%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Summary.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Summary%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L145">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L145">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Summary_" data-uid="Oqtane.Controllers.Data.Summary*"></a>
   <h4 id="Oqtane_Controllers_Data_Summary" data-uid="Oqtane.Controllers.Data.Summary">Summary</h4>
@@ -368,10 +368,10 @@ public string Summary { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Tags.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Tags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Tags.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Tags%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L160">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L160">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Tags_" data-uid="Oqtane.Controllers.Data.Tags*"></a>
   <h4 id="Oqtane_Controllers_Data_Tags" data-uid="Oqtane.Controllers.Data.Tags">Tags</h4>
@@ -399,10 +399,10 @@ public string[] Tags { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Title.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Title%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Title.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Title%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L148">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L148">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Title_" data-uid="Oqtane.Controllers.Data.Title*"></a>
   <h4 id="Oqtane_Controllers_Data_Title" data-uid="Oqtane.Controllers.Data.Title">Title</h4>
@@ -430,10 +430,10 @@ public string Title { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_TotalDownloads.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.TotalDownloads%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_TotalDownloads.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.TotalDownloads%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L166">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L166">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_TotalDownloads_" data-uid="Oqtane.Controllers.Data.TotalDownloads*"></a>
   <h4 id="Oqtane_Controllers_Data_TotalDownloads" data-uid="Oqtane.Controllers.Data.TotalDownloads">TotalDownloads</h4>
@@ -461,10 +461,10 @@ public long TotalDownloads { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Type.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Type.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L130">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L130">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Type_" data-uid="Oqtane.Controllers.Data.Type*"></a>
   <h4 id="Oqtane_Controllers_Data_Type" data-uid="Oqtane.Controllers.Data.Type">Type</h4>
@@ -492,10 +492,10 @@ public string Type { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Url.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Url%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Url.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Url%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L127">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L127">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Url_" data-uid="Oqtane.Controllers.Data.Url*"></a>
   <h4 id="Oqtane_Controllers_Data_Url" data-uid="Oqtane.Controllers.Data.Url">Url</h4>
@@ -523,10 +523,10 @@ public Uri Url { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Verified.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Verified%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Verified.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Verified%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L169">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L169">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Verified_" data-uid="Oqtane.Controllers.Data.Verified*"></a>
   <h4 id="Oqtane_Controllers_Data_Verified" data-uid="Oqtane.Controllers.Data.Verified">Verified</h4>
@@ -554,10 +554,10 @@ public bool Verified { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Version.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Version%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Version.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Version%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L139">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L139">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Version_" data-uid="Oqtane.Controllers.Data.Version*"></a>
   <h4 id="Oqtane_Controllers_Data_Version" data-uid="Oqtane.Controllers.Data.Version">Version</h4>
@@ -585,10 +585,10 @@ public string Version { get; set; }</code></pre>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Versions.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Versions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data_Versions.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data.Versions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L172">View Source</a>
+    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L172">View Source</a>
   </span>
   <a id="Oqtane_Controllers_Data_Versions_" data-uid="Oqtane.Controllers.Data.Versions*"></a>
   <h4 id="Oqtane_Controllers_Data_Versions" data-uid="Oqtane.Controllers.Data.Versions">Versions</h4>
@@ -622,10 +622,10 @@ public Version[] Versions { get; set; }</code></pre>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/new/dev/apiSpec/new?filename=Oqtane_Controllers_Data.md&amp;value=---%0Auid%3A%20Oqtane.Controllers.Data%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L125" class="contribution-link">View Source</a>
+                    <a href="https://github.com/oqtane/oqtane.framework/blob/dev/Oqtane.Server/Controllers/PackageController.cs/#L125" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -116,7 +116,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/articles/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/articles/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/intro.html
+++ b/docs/articles/intro.html
@@ -107,7 +107,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/articles/intro.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/articles/intro.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/2sic-forks/oqtane.docs/blob/master/Oqtane.Docs/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/oqtane/oqtane.docs/blob/master/Oqtane.Docs/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Fixes #10

This PR updates the contribution link to the current repo branch for Oqtane Framework.

Phew... I think I found them all.  These files are not shown in the solution when opened.  Still green here, did all these by hand.  I can see why not as many contributions as we all would like to see.  Hope this helps.

Note:  PR #17 could share files that have been changed.  Let me know if I need to review after merging or if things looked like they went OK.

Cheers!