### PR TITLE
Manual index.md enhancement

### DIFF
--- a/docs-src/pages/manuals/index.md
+++ b/docs-src/pages/manuals/index.md
@@ -24,25 +24,27 @@ This documentation is organized with your productivity in mind:
 
 Here are just a few of the powerful features you can learn about:
 
-### 🔧 Installation
+### 🔧 [Installation](installation/index.md)
 - **[Installation Wizard](installation/installation-wizard.md)**: Set up your first Oqtane instance with ease.
 - **[Configuration Tips](installation/index.md)**: Troubleshoot database connections, file permissions, and environment variables.
 
-### 🖼️ Content Management
+### 🖼️ [Content Management](content/index.md)
 - **[Control Panel](content/control-panel.md)**: Access site-wide tools from any page.
 - **[Page & Module Management](content/page-management.md)**: Create, edit, and organize your site's content structure.
 - **[Content Editor](content/content-editor.md)**: Inline editing tools to modify layout and styling on the fly.
 
-### 🛠 Site Administration (Admin)
+### 🛠 [Site Administration (Admin)](site/index.md)
 - **[Site Settings](site/site-settings.md)**: Manage site-specific configuration including logos, component settings, smtp settings, cookie consent and more.
 - **[User and Role Management](site/user-management.md)**: Create users, assign permissions, and manage profiles.
 - **[File & Folder Management](site/file-management.md)**: Upload, organize, and serve files across the site.
 - **[Visitor Logs & Recycle Bin](site/recycle-bin.md)**: Maintain site hygiene and recover deleted items.
-
-### 🧑‍💼 System Administration (Host)
+- 
+### 🧑‍💼 [System Administration (Host)](system/index.md)
 - **[Event Log](system/event-log.md)**: View and diagnose system-wide events.
-- **[System Info](system/system-info.md)**: Access detailed diagnostics and environment settings.
+- **[System Info](system/system-info.md)**: Access diagnostics, environment data, and runtime options like logging and Swagger.
+- **[System Update](system/system-update.md)**: Update the platform via direct download or NuGet upload.
 - **[Scheduled Jobs](system/scheduled-jobs.md)**: Automate and monitor background tasks.
+- **[SQL Management](system/sql-management.md)**: Run direct SQL queries securely from the browser.
 
 ---
 

--- a/docs-src/pages/manuals/index.md
+++ b/docs-src/pages/manuals/index.md
@@ -26,7 +26,7 @@ Here are just a few of the powerful features you can learn about:
 
 ### 🔧 [Installation](installation/index.md)
 - **[Installation Wizard](installation/installation-wizard.md)**: Set up your first Oqtane instance with ease.
-- **[Configuration Tips](installation/index.md)**: Troubleshoot database connections, file permissions, and environment variables.
+- **[Configuration Tips](installation/troubleshooting.md)**: Troubleshoot database connections, file permissions, and environment variables.
 
 ### 🖼️ [Content Management](content/index.md)
 - **[Control Panel](content/control-panel.md)**: Access site-wide tools from any page.

--- a/docs-src/pages/manuals/index.md
+++ b/docs-src/pages/manuals/index.md
@@ -1,13 +1,70 @@
 # Oqtane User Manuals
 
-## Introduction
+Welcome to the **Oqtane User Manuals** — your centralized hub for managing and customizing your Oqtane platform.
 
-This administrative documentation outlines the various ways that administrators and user can interact with the oqtane platform in a variety of ways, including but not limited to:
+Whether you're a new user exploring the basics or an experienced administrator managing complex deployments, this guide will walk you through essential features using clear, structured instructions.
 
-* Basic installation instructions.
-* The different processes of the control panel.
-* What the admin dashboard includes.
-* Content management for adding modules to pages, moving them around and editing them.
-* Administrative functions, such as file and user management.
-* Various host administrative tasks, such as jobs, event logs, installing modules and themes.
-* Basic development features like creating modules and themes from the related admin dashboard features.
+---
+
+## 🧭 How to Navigate
+
+This documentation is organized with your productivity in mind:
+
+- **Left Sidebar**: Use the navigation tree to browse topics by category (e.g., Content Management, Site Administration).
+- **Top Navbar**: Quickly jump to other key areas:
+  - **Guides** – for step-by-step tutorials and practical examples.
+  - **User Manuals** – where you are now, focused on platform features.
+  - **Develop** – for developers building modules, themes, and integrations.
+  - **API Documentation** – for low-level backend integrations and custom API work.
+- **Right Panel**: View page-specific anchors for fast jumping within each document.
+
+---
+
+## 🔍 What You'll Find in the User Manuals
+
+Here are just a few of the powerful features you can learn about:
+
+### 🔧 Installation
+- **[Installation Wizard](installation/installation-wizard.md)**: Set up your first Oqtane instance with ease.
+- **[Configuration Tips](installation/index.md)**: Troubleshoot database connections, file permissions, and environment variables.
+
+### 🖼️ Content Management
+- **[Control Panel](content/control-panel.md)**: Access site-wide tools from any page.
+- **[Page & Module Management](content/page-management.md)**: Create, edit, and organize your site's content structure.
+- **[Content Editor](content/content-editor.md)**: Inline editing tools to modify layout and styling on the fly.
+
+### 🛠 Site Administration (Admin)
+- **[Site Settings](site/site-settings.md)**: Manage site-specific configuration including logos, component settings, smtp settings, cookie consent and more.
+- **[User and Role Management](site/user-management.md)**: Create users, assign permissions, and manage profiles.
+- **[File & Folder Management](site/file-management.md)**: Upload, organize, and serve files across the site.
+- **[Visitor Logs & Recycle Bin](site/recycle-bin.md)**: Maintain site hygiene and recover deleted items.
+
+### 🧑‍💼 System Administration (Host)
+- **[Event Log](system/event-log.md)**: View and diagnose system-wide events.
+- **[System Info](system/system-info.md)**: Access detailed diagnostics and environment settings.
+- **[Scheduled Jobs](system/scheduled-jobs.md)**: Automate and monitor background tasks.
+
+---
+
+## ✅ Getting Started Checklist
+
+To get up and running quickly:
+
+1. **[Install Oqtane](installation/installation-wizard.md)** using the setup wizard.
+2. **Log in** as host or admin to unlock management tools.
+3. Use the **Control Panel** to navigate content and settings.
+4. Customize your site layout with the **Content Editor**.
+5. Explore advanced system and developer tools in the **System** section.
+
+---
+
+## 📚 Need More?
+
+- Visit the **[Guides section](../../guides/index.md)** for in-depth tutorials.
+- Join our community via [GitHub Discussions](https://github.com/oqtane/oqtane.framework/discussions).
+
+> Tip: Bookmark this page or your favorite section for quick access during development or administration tasks.
+
+---
+
+Oqtane is modular, modern, and open — and so is this documentation.

--- a/docs-src/pages/manuals/index.md
+++ b/docs-src/pages/manuals/index.md
@@ -67,6 +67,3 @@ To get up and running quickly:
 
 > Tip: Bookmark this page or your favorite section for quick access during development or administration tasks.
 
----
-
-Oqtane is modular, modern, and open — and so is this documentation.

--- a/docs-src/pages/manuals/index.md
+++ b/docs-src/pages/manuals/index.md
@@ -62,7 +62,7 @@ To get up and running quickly:
 
 ## 📚 Need More?
 
-- Visit the **[Guides section](../../guides/index.md)** for in-depth tutorials.
+- Visit the **[Guides section](../guides/index.md)** for in-depth tutorials.
 - Join our community via [GitHub Discussions](https://github.com/oqtane/oqtane.framework/discussions).
 
 > Tip: Bookmark this page or your favorite section for quick access during development or administration tasks.


### PR DESCRIPTION
This PR is a meant to enhance the documentation landing page for the manual index.md giving some added instruction on how to use documentation and options for the user to explore.

It can be added or not as I will leave this and any modifications after up to the maintainer to decide.  Current index.md content is brief and to the point.  This adds a little more color to the overall experience.

I did not add this with the 6.1.2 update so it can be merged or not merged independently. 

6.1.2 update focuses on just that and anything that was missing that needed to be added, enhanced or pushed forward.

This floats an idea no issue made.