### PR TITLE
Fixes #112: DocFX metadata build fails on v6.2 due to `.razor` file reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ To set everything up, follow the instructions on <https://docs.oqtane.org/dev/do
 
 For further discussions, feedback, or questions, head over to [GitHub Discussions](https://github.com/oqtane/oqtane.docs/discussions).
 
+## NPM Scripts
+
+`cd docs-src`
+
+- `npm run docfx-metadata` – runs the wrapper script that injects temporary stubs and executes `docfx metadata`.
+- `npm run docfx-build` – run `docfx build` to regenerate the output in `../docs`.
+- `npm run docfx-serve` – runs the build metadata pipeline and then starts `docfx serve ../docs --hostname localhost --port 8080`.
+
+_All three commands rely on PowerShell (`pwsh`) being available on your PATH._
+
 ## Join Our Community
 
 For more interactive discussions and community support, join us on Discord!

--- a/README.md
+++ b/README.md
@@ -6,19 +6,13 @@ It's published on [docs.oqtane.org](https://docs.oqtane.org).
 
 ## Setup, Build & Publish
 
+First, open the workspace in the `docs-src` folder.
+
+DocFx tasks are define in `docs-src/.vscode/tasks.json` and can be run from the Command Palette (`Ctrl+Shift+P`).
+
 To set everything up, follow the instructions on <https://docs.oqtane.org/dev/docs/index.html/>.
 
 For further discussions, feedback, or questions, head over to [GitHub Discussions](https://github.com/oqtane/oqtane.docs/discussions).
-
-## NPM Scripts
-
-`cd docs-src`
-
-- `npm run docfx-metadata` – runs the wrapper script that injects temporary stubs and executes `docfx metadata`.
-- `npm run docfx-build` – run `docfx build` to regenerate the output in `../docs`.
-- `npm run docfx-serve` – runs the build metadata pipeline and then starts `docfx serve ../docs --hostname localhost --port 8080`.
-
-_All three commands rely on PowerShell (`pwsh`) being available on your PATH._
 
 ## Join Our Community
 

--- a/docs-src/.vscode/tasks.json
+++ b/docs-src/.vscode/tasks.json
@@ -11,20 +11,34 @@
         "runOn": "folderOpen"
       }
     },
-    {
-      "label": "docfx: build docs (skip building API, faster for documentation)",
-      "type": "shell",
-      "command": "docfx build",
-      "group": "build",
-      "presentation": {
-        "reveal": "always"
-      }
-    },
+    // {
+    //   "label": "build",
+    //   "command": "dotnet",
+    //   "type": "shell",
+    //   "args": [
+    //     "build",
+    //     // Ask dotnet build to generate full paths for file names.
+    //     "/property:GenerateFullPaths=true",
+    //     // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+    //     "/consoleloggerparameters:NoSummary"
+    //   ],
+    //   "group": "build",
+    //   "presentation": {
+    //     "reveal": "silent"
+    //   },
+    //   "problemMatcher": "$msCompile"
+    // }
     {
       "label": "build",
-      "command": "dotnet",
       "type": "shell",
+      "command": "pwsh",
       "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/docfx-support/run.ps1",
+        "dotnet",
         "build",
         // Ask dotnet build to generate full paths for file names.
         "/property:GenerateFullPaths=true",
@@ -36,6 +50,51 @@
         "reveal": "silent"
       },
       "problemMatcher": "$msCompile"
-    }
+    },
+    // {
+    //   "label": "docfx: build docs (skip building API, faster for documentation)",
+    //   "type": "shell",
+    //   "command": "docfx build",
+    //   "group": "build",
+    //   "presentation": {
+    //     "reveal": "always"
+    //   }
+    // },
+    {
+      "label": "docfx: build docs (skip building API, faster for documentation) with stub generation",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/docfx-support/run.ps1",
+        "docfx",
+        "build"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always"
+      }
+    },
+    {
+      "label": "docfx: metadata",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/docfx-support/run.ps1",
+        "docfx",
+        "metadata"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always"
+      }
+    },
   ]
 }

--- a/docs-src/.vscode/tasks.json
+++ b/docs-src/.vscode/tasks.json
@@ -96,5 +96,25 @@
         "reveal": "always"
       }
     },
+        {
+      "label": "docfx: serve",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/docfx-support/run.ps1",
+        ";",
+        "docfx",
+        "serve",
+        "../docs"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always"
+      }
+    },
   ]
 }

--- a/docs-src/docfx-support/run.ps1
+++ b/docs-src/docfx-support/run.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 $scriptRoot = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $docsSrc = Resolve-Path (Join-Path $scriptRoot "..")
-$repoRoot = Resolve-Path (Join-Path $docsSrc "..\..")
+$repoRoot = Resolve-Path (Join-Path $docsSrc ".." "..")
 $frameworkRoot = Join-Path $repoRoot "oqtane.framework"
 if (-not (Test-Path $frameworkRoot)) {
     throw "Expected oqtane.framework sibling folder at '$frameworkRoot'."

--- a/docs-src/docfx-support/run.ps1
+++ b/docs-src/docfx-support/run.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$DocfxCommand = "docfx",
+    [string[]]$DocfxArgs = @("metadata")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+$docsSrc = Resolve-Path (Join-Path $scriptRoot "..")
+$repoRoot = Resolve-Path (Join-Path $docsSrc "..\..")
+$frameworkRoot = Join-Path $repoRoot "oqtane.framework"
+if (-not (Test-Path $frameworkRoot)) {
+    throw "Expected oqtane.framework sibling folder at '$frameworkRoot'."
+}
+
+$stubSource = Join-Path $scriptRoot "stubs\RadzenTextEditorStub.cs"
+if (-not (Test-Path $stubSource)) {
+    throw "Stub source '$stubSource' not found."
+}
+
+$stubDestination = Join-Path $frameworkRoot "Oqtane.Client\Modules\Controls\TextEditors\Radzen\RadzenTextEditor.DocfxStub.cs"
+$hadExistingStub = Test-Path $stubDestination
+
+try {
+    Copy-Item -Path $stubSource -Destination $stubDestination -Force
+
+    Push-Location $docsSrc
+    try {
+        & $DocfxCommand @DocfxArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "docfx exited with code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    if (-not $hadExistingStub -and (Test-Path $stubDestination)) {
+        Remove-Item $stubDestination -Force
+    }
+}

--- a/docs-src/docfx-support/run.ps1
+++ b/docs-src/docfx-support/run.ps1
@@ -19,7 +19,7 @@ if (-not (Test-Path $stubSource)) {
     throw "Stub source '$stubSource' not found."
 }
 
-$stubDestination = Join-Path $frameworkRoot "Oqtane.Client\Modules\Controls\TextEditors\Radzen\RadzenTextEditor.DocfxStub.cs"
+$stubDestination = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $frameworkRoot 'Oqtane.Client') 'Modules') 'Controls') 'TextEditors\Radzen\RadzenTextEditor.DocfxStub.cs')
 $hadExistingStub = Test-Path $stubDestination
 
 try {

--- a/docs-src/docfx-support/run.ps1
+++ b/docs-src/docfx-support/run.ps1
@@ -14,12 +14,12 @@ if (-not (Test-Path $frameworkRoot)) {
     throw "Expected oqtane.framework sibling folder at '$frameworkRoot'."
 }
 
-$stubSource = Join-Path $scriptRoot "stubs\RadzenTextEditorStub.cs"
+$stubSource = Join-Path $scriptRoot "stubs" "RadzenTextEditor.placeholder.cs"
 if (-not (Test-Path $stubSource)) {
     throw "Stub source '$stubSource' not found."
 }
 
-$stubDestination = Join-Path (Join-Path (Join-Path (Join-Path (Join-Path $frameworkRoot 'Oqtane.Client') 'Modules') 'Controls') 'TextEditors\Radzen\RadzenTextEditor.DocfxStub.cs')
+$stubDestination = Join-Path $frameworkRoot "Oqtane.Client" "Modules" "Controls" "TextEditors" "Radzen" "RadzenTextEditor.DocfxStub.cs"
 $hadExistingStub = Test-Path $stubDestination
 
 try {

--- a/docs-src/docfx-support/stubs/RadzenTextEditor.placeholder.cs
+++ b/docs-src/docfx-support/stubs/RadzenTextEditor.placeholder.cs
@@ -1,0 +1,13 @@
+// This is just a placeholder file
+// It is necessary for the documentation to successfully build this project.
+// Reason is that docfx will run the .net compiler and find references
+// to this class in the project.
+// But since the real class is just a .razor file, ATM docfx will fail.
+//
+// Note added 2025-09-22 by @tvatavuk.
+// We hope that as .net and docfx improve, the razor-compiler will work in that scenario
+// as well, and this file can be removed.
+
+namespace Oqtane.Modules.Controls;
+public partial class RadzenTextEditor;
+

--- a/docs-src/docfx-support/stubs/RadzenTextEditorStub.cs
+++ b/docs-src/docfx-support/stubs/RadzenTextEditorStub.cs
@@ -1,6 +1,0 @@
-namespace Oqtane.Modules.Controls
-{
-    public class RadzenTextEditor
-    {
-    }
-}

--- a/docs-src/docfx-support/stubs/RadzenTextEditorStub.cs
+++ b/docs-src/docfx-support/stubs/RadzenTextEditorStub.cs
@@ -1,0 +1,6 @@
+namespace Oqtane.Modules.Controls
+{
+    public class RadzenTextEditor
+    {
+    }
+}

--- a/docs-src/docfx.json
+++ b/docs-src/docfx.json
@@ -25,6 +25,12 @@
       "filter": "filterConfig.yml",
       "properties": {
         // "TargetFramework": "net9.0"
+        // "SkipCompilerExecution": "false", 
+        // "EnableDefaultRazorComponentItems": "true", // include Blazor components in the API docs
+        // "RazorGenerateOutputFileExtension": ".razor.cs", // ensure Razor components are treated as C# files
+        // "EmbedRazorGenerateSources": "true" // ensure Razor components are treated as C# files
+        // "UseRazorSourceGenerator": "true", // ensure Razor components are treated as C# files
+        // "GenerateRazorMetadata": "true" // ensure Razor components are treated as C# files
       },
       "namespaceLayout": "nested", // make APIs use a tree
     }

--- a/docs-src/docfx.json
+++ b/docs-src/docfx.json
@@ -12,6 +12,7 @@
             "**/obj/**",
             "**/bin/**",
             "_site/**",
+            "Oqtane.Application/**",
             "Oqtane.Test",
             "Oqtane.Database.*",
             "Oqtane.Maui/**",

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -9,7 +9,7 @@
     "webpack-dev": "webpack --watch --mode development -c ./templates/shared-global/webpack.config.js",
     "docfx-metadata": "pwsh ./docfx-support/run.ps1 docfx metadata",
     "docfx-build": "pwsh -NoProfile -Command \"& { docfx build }\"",
-    "docfx-serve": "pwsh -NoProfile -Command \"& { ./docfx-support/run.ps1 docfx metadata; docfx serve ../docs --hostname localhost --port 8080 }\""
+    "docfx-serve": "pwsh -NoProfile -Command \"& { ./docfx-support/run.ps1 docfx metadata && docfx serve ../docs --hostname localhost --port 8080 }\""
   },
   "author": "",
   "license": "ISC",

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -6,7 +6,10 @@
   "enableDebug": false,
   "scripts": {
     "webpack-build": "webpack --mode production -c ./templates/shared-global/webpack.config.js",
-    "webpack-dev": "webpack --watch --mode development -c ./templates/shared-global/webpack.config.js"
+    "webpack-dev": "webpack --watch --mode development -c ./templates/shared-global/webpack.config.js",
+    "docfx-metadata": "pwsh ./docfx-support/run.ps1 docfx metadata",
+    "docfx-build": "pwsh -NoProfile -Command \"& { docfx build }\"",
+    "docfx-serve": "pwsh -NoProfile -Command \"& { ./docfx-support/run.ps1 docfx metadata; docfx serve ../docs --hostname localhost --port 8080 }\""
   },
   "author": "",
   "license": "ISC",

--- a/docs-src/package.json
+++ b/docs-src/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "webpack-build": "webpack --mode production -c ./templates/shared-global/webpack.config.js",
     "webpack-dev": "webpack --watch --mode development -c ./templates/shared-global/webpack.config.js",
-    "docfx-metadata": "pwsh ./docfx-support/run.ps1 docfx metadata",
-    "docfx-build": "pwsh -NoProfile -Command \"& { docfx build }\"",
-    "docfx-serve": "pwsh -NoProfile -Command \"& { ./docfx-support/run.ps1 docfx metadata && docfx serve ../docs --hostname localhost --port 8080 }\""
+    // "docfx-metadata": "pwsh ./docfx-support/run.ps1 docfx metadata",
+    // "docfx-build": "pwsh -NoProfile -Command \"& { docfx build }\"",
+    // "docfx-serve": "pwsh -NoProfile -Command \"& { ./docfx-support/run.ps1 docfx metadata && docfx serve ../docs --hostname localhost --port 8080 }\""
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Fixes: https://github.com/oqtane/oqtane.docs/issues/112

Added a DocFX-only stub plus a wrapper script so the docs build can supply the missing Razor-generated type without touching `oqtane.framework`.

* **Stub**: `docfx-support/stubs/RadzenTextEditorStub.cs:1`
  Declares an empty `Oqtane.Modules.Controls.RadzenTextEditor` class.
* **Helper script**: `docfx-support/run.ps1:1`
  Copies the stub into the client project, runs `docfx metadata`, then deletes the temporary file (even on failure).

Running

```powershell
.\docfx-support\run.ps1
```

now completes the metadata phase (aside from the existing XML-comment warning) with zero build errors.

<img width="3840" height="2088" alt="image" src="https://github.com/user-attachments/assets/9bc3761f-54aa-4fbe-a445-2c7ba9534067" />

---

### Automation

Wired the new script with `npm` into automation so stub injection/cleanup happens automatically:

* `npm run docfx-metadata` – runs the wrapper script that injects temporary stubs and executes `docfx metadata`.
* `npm run docfx-build` – runs `docfx build` to regenerate the output in `../docs`.
* `npm run docfx-serve` – runs the build metadata pipeline and then starts `docfx serve ../docs --hostname localhost --port 8080`.

---

### Notes

* This is a **workaround** to unblock documentation builds for v6.2.
* A longer-term fix would be to enable proper Razor source generation in the DocFX metadata build, but this ensures docs build cleanly in the meantime.